### PR TITLE
Improve project grid and detail page layout

### DIFF
--- a/src/app/projects/[slug]/page.module.css
+++ b/src/app/projects/[slug]/page.module.css
@@ -25,22 +25,46 @@
     position: relative;
     aspect-ratio: 16/9;
     width: 100%;
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-radius: 12px;
     overflow: hidden;
 }
 .heroImg {
     object-fit: cover;
 }
 
+.heroOverlay {
+    position: absolute;
+    inset: auto 0 0 0;
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    color: white;
+    background: linear-gradient(
+        to top,
+        rgba(0, 0, 0, 0.55),
+        rgba(0, 0, 0, 0)
+    );
+}
+
+.badge {
+    display: inline-block;
+    font-size: var(--font-size-small);
+    background: rgba(255, 255, 255, 0.95);
+    color: rgb(var(--accent-color-2-rgb));
+    padding: 2px 10px;
+    border-radius: 999px;
+}
+
 .title {
-    margin-top: 1rem;
+    margin: 0;
     font-size: var(--font-size-x3large);
-    color: rgb(var(--accent-color-contrast-rgb));
+    color: white;
 }
 .summary {
     max-width: 70ch;
-    margin: 0.5rem auto 0;
+    margin: 1rem auto 0;
     opacity: 0.85;
 }
 

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -29,8 +29,11 @@ export default function ProjectDetail({ params }: { params: Params }) {
                         sizes="(max-width: 768px) 100vw, 100vw"
                         priority
                     />
+                    <div className={styles.heroOverlay}>
+                        <span className={styles.badge}>{project.category}</span>
+                        <h1 className={styles.title}>{project.title}</h1>
+                    </div>
                 </div>
-                <h1 className={styles.title}>{project.title}</h1>
                 {project.summary && (
                     <p className={styles.summary}>{project.summary}</p>
                 )}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -25,7 +25,7 @@ const Page = async ({
 
     // filter by category
     const filtered =
-        tabStr === "all" || !CATS.includes(tabStr as any)
+        tabStr === "all" || !CATS.includes(tabStr as typeof CATS[number])
             ? projects
             : projects.filter((p) => p.category === tabStr);
 

--- a/src/features/projects-page/components/ProjectGrid/style.module.css
+++ b/src/features/projects-page/components/ProjectGrid/style.module.css
@@ -1,9 +1,9 @@
 .grid {
     display: grid;
     grid-template-columns: repeat(
-        auto-fill,
-        minmax(180px, 1fr)
-    ); /* responsive */
+        auto-fit,
+        minmax(clamp(260px, 33vw, 480px), 1fr)
+    ); /* responsive, cards grow on wide screens */
     gap: var(--padding-small);
     justify-items: stretch; /* cards fill column width */
     justify-content: start; /* LEFT-ALIGNED grid */


### PR DESCRIPTION
## Summary
- Allow project cards to scale larger on wide screens for a more modern grid
- Redesign project detail pages with hero overlay and category badge
- Fix lint warning for project category filtering

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bddfe18b088327aaaaddcbfa5105de